### PR TITLE
Change "Replace" switch parameter to "Force"

### DIFF
--- a/AudioWorks/src/AudioWorks.Commands/ExportAudioCoverArtCommand.cs
+++ b/AudioWorks/src/AudioWorks.Commands/ExportAudioCoverArtCommand.cs
@@ -35,7 +35,8 @@ namespace AudioWorks.Commands
         public string? Name { get; set; }
 
         [Parameter]
-        public SwitchParameter Replace { get; set; }
+        [Alias("Replace")]
+        public SwitchParameter Force { get; set; }
 
         protected override void BeginProcessing()
         {
@@ -44,7 +45,7 @@ namespace AudioWorks.Commands
             _extractor = new CoverArtExtractor(
                     SessionState.Path.GetUnresolvedProviderPathFromPSPath(Path),
                     Name)
-                { Overwrite = Replace };
+                { Overwrite = Force };
         }
 
         protected override void ProcessRecord()

--- a/AudioWorks/src/AudioWorks.Commands/ExportAudioCoverArtCommand.cs
+++ b/AudioWorks/src/AudioWorks.Commands/ExportAudioCoverArtCommand.cs
@@ -35,7 +35,6 @@ namespace AudioWorks.Commands
         public string? Name { get; set; }
 
         [Parameter]
-        [Alias("Replace")]
         public SwitchParameter Force { get; set; }
 
         protected override void BeginProcessing()

--- a/AudioWorks/src/AudioWorks.Commands/ExportAudioFileCommand.cs
+++ b/AudioWorks/src/AudioWorks.Commands/ExportAudioFileCommand.cs
@@ -46,7 +46,6 @@ namespace AudioWorks.Commands
         public string? Name { get; set; }
 
         [Parameter]
-        [Alias("Replace")]
         public SwitchParameter Force { get; set; }
 
         [Parameter, ValidateRange(1, int.MaxValue)]

--- a/AudioWorks/src/AudioWorks.Commands/ExportAudioFileCommand.cs
+++ b/AudioWorks/src/AudioWorks.Commands/ExportAudioFileCommand.cs
@@ -46,7 +46,8 @@ namespace AudioWorks.Commands
         public string? Name { get; set; }
 
         [Parameter]
-        public SwitchParameter Replace { get; set; }
+        [Alias("Replace")]
+        public SwitchParameter Force { get; set; }
 
         [Parameter, ValidateRange(1, int.MaxValue)]
         public int MaxDegreeOfParallelism { get; set; } = Environment.ProcessorCount;
@@ -61,7 +62,7 @@ namespace AudioWorks.Commands
                 Name,
                 SettingAdapter.ParametersToSettings(_parameters))
             {
-                Overwrite = Replace,
+                Overwrite = Force,
                 MaxDegreeOfParallelism = MaxDegreeOfParallelism
             };
 

--- a/AudioWorks/src/AudioWorks.Commands/RenameAudioFileCommand .cs
+++ b/AudioWorks/src/AudioWorks.Commands/RenameAudioFileCommand .cs
@@ -28,7 +28,6 @@ namespace AudioWorks.Commands
         public ITaggedAudioFile? AudioFile { get; set; }
 
         [Parameter]
-        [Alias("Replace")]
         public SwitchParameter Force { get; set; }
 
         [Parameter]

--- a/AudioWorks/src/AudioWorks.Commands/RenameAudioFileCommand .cs
+++ b/AudioWorks/src/AudioWorks.Commands/RenameAudioFileCommand .cs
@@ -28,14 +28,15 @@ namespace AudioWorks.Commands
         public ITaggedAudioFile? AudioFile { get; set; }
 
         [Parameter]
-        public SwitchParameter Replace { get; set; }
+        [Alias("Replace")]
+        public SwitchParameter Force { get; set; }
 
         [Parameter]
         public SwitchParameter PassThru { get; set; }
 
         protected override void ProcessRecord()
         {
-            AudioFile!.Rename(Name!, Replace);
+            AudioFile!.Rename(Name!, Force);
 
             ProcessLogMessages();
 

--- a/AudioWorks/src/AudioWorks.Commands/docs/Export-AudioCoverArt.md
+++ b/AudioWorks/src/AudioWorks.Commands/docs/Export-AudioCoverArt.md
@@ -13,7 +13,7 @@ Exports cover art from an audio file.
 ## SYNTAX
 
 ```
-Export-AudioCoverArt [-Path] <String> [-AudioFile] <ITaggedAudioFile> [-Name <String>] [-Replace]
+Export-AudioCoverArt [-Path] <String> [-AudioFile] <ITaggedAudioFile> [-Name <String>] [-Force]
  [<CommonParameters>]
 ```
 
@@ -89,8 +89,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Replace
-Indicates that existing files should be replaced.
+### -Force
+Indicates that existing files should be overwritten.
 
 ```yaml
 Type: SwitchParameter

--- a/AudioWorks/src/AudioWorks.Commands/docs/Export-AudioFile.md
+++ b/AudioWorks/src/AudioWorks.Commands/docs/Export-AudioFile.md
@@ -14,7 +14,7 @@ Exports an audio file.
 
 ```
 Export-AudioFile [-Encoder] <String> [-Path] <String> [-AudioFile] <ITaggedAudioFile> [-Name <String>]
- [-Replace] [-MaxDegreeOfParallelism <Int32>] [<CommonParameters>]
+ [-Force] [-MaxDegreeOfParallelism <Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -31,7 +31,7 @@ Exports test.flac as test.mp3 using default settings, in the current directory.
 
 ### Example 2: Re-encode an audio file in-place
 ```powershell
-PS C:\> Get-AudioFile test.flac | Export-AudioFile FLAC . -Replace
+PS C:\> Get-AudioFile test.flac | Export-AudioFile FLAC . -Force
 ```
 
 Re-encodes test.flac in-place, using default settings.
@@ -111,8 +111,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Replace
-Indicates that existing files should be replaced.
+### -Force
+Indicates that existing files should be overwritten.
 
 ```yaml
 Type: SwitchParameter

--- a/AudioWorks/src/AudioWorks.Commands/docs/Rename-AudioFile.md
+++ b/AudioWorks/src/AudioWorks.Commands/docs/Rename-AudioFile.md
@@ -13,7 +13,7 @@ Renames an audio file.
 ## SYNTAX
 
 ```
-Rename-AudioFile [-Name] <String> [-AudioFile] <ITaggedAudioFile> [-Replace] [-PassThru] [<CommonParameters>]
+Rename-AudioFile [-Name] <String> [-AudioFile] <ITaggedAudioFile> [-Force] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -64,8 +64,8 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Replace
-Indicates that existing files should be replaced.
+### -Force
+Indicates that existing files should be overwritten.
 
 ```yaml
 Type: SwitchParameter

--- a/AudioWorks/tests/AudioWorks.Commands.Tests/ExportAudioCoverArtTests.cs
+++ b/AudioWorks/tests/AudioWorks.Commands.Tests/ExportAudioCoverArtTests.cs
@@ -122,7 +122,7 @@ namespace AudioWorks.Commands.Tests
                         new TaggedAudioFile(Path.Combine(PathUtility.GetTestFileRoot(), "Valid", sourceFileName)))
                     .AddParameter("Path", Path.Combine("Output", "Export-AudioCoverArt"))
                     .AddParameter("Name", $"{index:000} - {Path.GetFileNameWithoutExtension(sourceFileName)}")
-                    .AddParameter("Replace");
+                    .AddParameter("Force");
 
                 var result = ps.Invoke();
 

--- a/AudioWorks/tests/AudioWorks.Commands.Tests/ExportAudioFileTests.cs
+++ b/AudioWorks/tests/AudioWorks.Commands.Tests/ExportAudioFileTests.cs
@@ -149,7 +149,7 @@ namespace AudioWorks.Commands.Tests
                     .AddArgument(sourceAudioFile)
                     .AddParameter("Path", Path.Combine("Output", "Export-AudioFile", "Valid"))
                     .AddParameter("Name", $"{index:000} - {Path.GetFileNameWithoutExtension(sourceFileName)}")
-                    .AddParameter("Replace");
+                    .AddParameter("Force");
                 foreach (var item in settings)
                     if (item.Value is bool boolValue)
                     {

--- a/AudioWorks/tests/AudioWorks.Commands.Tests/RenameAudioFileTests.cs
+++ b/AudioWorks/tests/AudioWorks.Commands.Tests/RenameAudioFileTests.cs
@@ -142,8 +142,8 @@ namespace AudioWorks.Commands.Tests
             }
         }
 
-        [Fact(DisplayName = "Rename-AudioFile accepts a Replace switch")]
-        public void AcceptsReplaceSwitch()
+        [Fact(DisplayName = "Rename-AudioFile accepts a Force switch")]
+        public void AcceptsForceSwitch()
         {
             using (var ps = PowerShell.Create())
             {
@@ -151,7 +151,7 @@ namespace AudioWorks.Commands.Tests
                 ps.AddCommand("Rename-AudioFile")
                     .AddParameter("AudioFile", new Mock<ITaggedAudioFile>().Object)
                     .AddParameter("Name", "Foo")
-                    .AddParameter("Replace");
+                    .AddParameter("Force");
 
                 ps.Invoke();
 
@@ -208,7 +208,7 @@ namespace AudioWorks.Commands.Tests
                 ps.AddCommand("Rename-AudioFile")
                     .AddParameter("AudioFile", audioFile)
                     .AddParameter("Name", "Foo")
-                    .AddParameter("Replace")
+                    .AddParameter("Force")
                     .AddParameter("PassThru");
 
                 Assert.Equal(audioFile, ps.Invoke()[0].BaseObject);
@@ -230,7 +230,7 @@ namespace AudioWorks.Commands.Tests
                 ps.AddCommand("Rename-AudioFile")
                     .AddParameter("AudioFile", audioFile)
                     .AddParameter("Name", name)
-                    .AddParameter("Replace");
+                    .AddParameter("Force");
 
                 ps.Invoke();
 


### PR DESCRIPTION
> Changed to follow standard PowerShell behavior of using "-Force" when overwriting files.
> Added "Replace" alias to preserve backwards compatibility.

Remaking pull request #21 and hoping things work correctly this time.